### PR TITLE
会員の有効・無効を返すメソッドの修正

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -107,6 +107,6 @@ class Member < ApplicationRecord
   end
 
   def display_deleted_text
-    is_deleted ? "有効" : "無効"
+    is_deleted ? "無効" : "有効"
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -215,12 +215,12 @@ RSpec.describe Member, type: :model do
       @member2 = create(:guest, is_deleted: false)
     end
 
-    it "返り値で有効を返すこと" do
-      expect(@member1.display_deleted_text).to eq "有効"
+    it "返り値で無効を返すこと" do
+      expect(@member1.display_deleted_text).to eq "無効"
     end
 
-    it "返り値で無効を返すこと" do
-      expect(@member2.display_deleted_text).to eq "無効"
+    it "返り値で有効を返すこと" do
+      expect(@member2.display_deleted_text).to eq "有効"
     end
   end
 end


### PR DESCRIPTION
  メソッドの有効、無効が逆になっていたため修正。