### PR TITLE
問い合わせ完了時、slackへの通知を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,3 +149,5 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'mast
 
 # 環境変数
 gem 'dotenv-rails'
+
+gem 'slack-notifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,6 +376,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
+    slack-notifier (2.3.2)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -485,6 +486,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   shoulda-matchers
+  slack-notifier
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/member/inquiry_controller.rb
+++ b/app/controllers/member/inquiry_controller.rb
@@ -13,6 +13,10 @@ class Member::InquiryController < ApplicationController
   def create
     @inquiry = current_member.inquiries.create!(inquiry_params)
     redirect_to thanks_member_inquiry_index_path
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error e.message
+    flash[:danger] = "エラーが発生しました!もう1度やり直してください。"
+    render :new
   end
 
   def thanks

--- a/app/controllers/member/inquiry_controller.rb
+++ b/app/controllers/member/inquiry_controller.rb
@@ -12,7 +12,10 @@ class Member::InquiryController < ApplicationController
 
   def create
     @inquiry = current_member.inquiries.create!(inquiry_params)
+
     MemberMailer.inquiry_mail(@inquiry).deliver_now
+    SlackNotifier.new.send("問い合わせがありました！")
+    
     redirect_to thanks_member_inquiry_index_path
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error e.message

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -1,0 +1,6 @@
+class SlackNotifier
+
+  def send(message)
+    Slack::Notifier.new(ENV['WEBHOOK_URL']).ping(message)
+  end
+end

--- a/app/views/member/inquiry/new.html.slim
+++ b/app/views/member/inquiry/new.html.slim
@@ -2,6 +2,9 @@
   .row
     .col-xs-3
     .col-xs-6
+      p.alert-danger
+          = flash[:danger]
+
       .inquiry_form
         h1 お問い合わせフォーム
         = form_with model: @inquiry, url: confirm_member_inquiry_index_path do |f|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,11 +29,7 @@ Rails.application.routes.draw do
       resources :clinics
       resources :consultation_hours, only: [:create, :update, :destroy]
       resources :genres, except: [:show]
-<<<<<<< HEAD
       resources :inquiry, only: [:index, :show]
-=======
-      
->>>>>>> parent of 45bb4c5... rubocopの違反レベルCのみ解消
     end
   # -------------------- admin ------------------------------------------------
   

--- a/spec/controllers/member/inquiry_controller_spec.rb
+++ b/spec/controllers/member/inquiry_controller_spec.rb
@@ -50,24 +50,48 @@ RSpec.describe Member::InquiryController, type: :controller do
   end
 
   describe "create" do
-    let(:params) do
+    context "入力した値が正常なとき" do
+      let(:params) do
+        {
+          inquiry: {
+            title: 'test',
+            content: 'testです',
+            member_id: @member.id
+          }
+        }
+      end
+
+      it "問い合わせを保存できるか" do
+        post :create, params: params
+        expect(@member.inquiries.size).to eq (1)
+      end
+
+      it "/member/inquiry/thanksにリダイレクトすること" do
+        post :create, params: params
+        expect(response).to redirect_to "/member/inquiry/thanks"
+      end
+    end
+
+    context "入力した値が正常でないとき" do
+      let(:params) do
       {
         inquiry: {
-          title: 'test',
+          title: nil,
           content: 'testです',
           member_id: @member.id
         }
       }
-    end
+      end
 
-    it "正常に問い合わせを保存できるか" do
-      post :create, params: params
-      expect(@member.inquiries.size).to eq (1)
-    end
+      it "flashメッセージを表示すること" do
+        post :create, params: params
+        expect(flash[:danger]).to be_present
+      end
 
-    it "/member/inquiry/thanksにリダイレクトすること" do
-      post :create, params: params
-      expect(response).to redirect_to "/member/inquiry/thanks"
+      it "newページがレンダリングされること" do
+        post :create, params: params
+        expect(response).to render_template :new
+      end
     end
   end
 

--- a/spec/models/slack_notifier_spec.rb
+++ b/spec/models/slack_notifier_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe SlackNotifier, :type => :model do
+
+  describe "#send" do
+    it "HTTPリクエスト(200)が送られているか" do
+      expect(SlackNotifier.new.send("hoge").first.code).to eq "200"
+    end
+  end
+end


### PR DESCRIPTION
## 概要
問い合わせ完了時、slackへの通知を実装

slackへの通知が他でも使用できるようSlackNotifierクラスを作成し
メソッドを定義した。
## 変更内容
## テストの有無
あり
### テスト結果
```
SlackNotifier
  #send
    HTTPリクエスト(200)が送られているか

Finished in 1.03 seconds (files took 2.85 seconds to load)
1 example, 0 failures
```
### ありの場合
<!-- 具体的なテスト項目を記載 -->
### なしの場合
<!-- 実装しなかった理由を記載 -->
### 動作確認
問い合わせ完了時にslackへ通知が送られるか。
