### PR TITLE
診療時間にenumを設定

### DIFF
--- a/app/models/consultation_hour.rb
+++ b/app/models/consultation_hour.rb
@@ -1,3 +1,12 @@
 class ConsultationHour < ApplicationRecord
   belongs_to :clinic, optional: true
+
+  enum mo_time: [:◯, :／, :△], _prefix: true
+  enum tu_time: [:◯, :／, :△], _prefix: true
+  enum we_time: [:◯, :／, :△], _prefix: true
+  enum th_time: [:◯, :／, :△], _prefix: true
+  enum fr_time: [:◯, :／, :△], _prefix: true
+  enum sa_time: [:◯, :／, :△], _prefix: true
+  enum su_time: [:◯, :／, :△], _prefix: true
+  enum ho_time: [:◯, :／, :△], _prefix: true
 end

--- a/app/views/member/favorites/create.json.jbuilder
+++ b/app/views/member/favorites/create.json.jbuilder
@@ -1,0 +1,3 @@
+json.id @favorite.id
+json.member_id @favorite.member_id
+json.clinic_id @favorite.clinic_id

--- a/spec/models/consultation_hour_spec.rb
+++ b/spec/models/consultation_hour_spec.rb
@@ -13,5 +13,15 @@ RSpec.describe ConsultationHour, type: :model do
       it { expect(association.class_name).to eq "Clinic" } 
     end
   end
-
+  
+  describe "enum" do
+    it { is_expected.to define_enum_for(:mo_time)}
+    it { is_expected.to define_enum_for(:tu_time)}
+    it { is_expected.to define_enum_for(:we_time)}
+    it { is_expected.to define_enum_for(:th_time)}
+    it { is_expected.to define_enum_for(:fr_time)}
+    it { is_expected.to define_enum_for(:sa_time)}
+    it { is_expected.to define_enum_for(:su_time)}
+    it { is_expected.to define_enum_for(:ho_time)}
+  end
 end


### PR DESCRIPTION
## 概要
診療時間にenumを設定
## 変更内容
## テストの有無
あり
### テスト結果
```
ConsultationHour
  enum
    is expected to define :mo_time as an enum backed by an integer
    is expected to define :tu_time as an enum backed by an integer
    is expected to define :we_time as an enum backed by an integer
    is expected to define :th_time as an enum backed by an integer
    is expected to define :fr_time as an enum backed by an integer
    is expected to define :sa_time as an enum backed by an integer
    is expected to define :su_time as an enum backed by an integer
    is expected to define :ho_time as an enum backed by an integer

Finished in 1.63 seconds (files took 1.47 seconds to load)
8 examples, 0 failures
```
### ありの場合
enumが有効かどうか
### なしの場合
<!-- 実装しなかった理由を記載 -->
### 動作確認
<!-- 期待する挙動と確認した手順を記載 -->
viewページ(クリニックの詳細ページ)を開いて確認
