### PR TITLE
診療時間の表示方法を修正

### DIFF
--- a/app/models/consultation_hour.rb
+++ b/app/models/consultation_hour.rb
@@ -1,12 +1,13 @@
 class ConsultationHour < ApplicationRecord
   belongs_to :clinic, optional: true
 
-  enum mo_time: [:◯, :／, :△], _prefix: true
-  enum tu_time: [:◯, :／, :△], _prefix: true
-  enum we_time: [:◯, :／, :△], _prefix: true
-  enum th_time: [:◯, :／, :△], _prefix: true
-  enum fr_time: [:◯, :／, :△], _prefix: true
-  enum sa_time: [:◯, :／, :△], _prefix: true
-  enum su_time: [:◯, :／, :△], _prefix: true
-  enum ho_time: [:◯, :／, :△], _prefix: true
+  def time_status(time)
+    if time == 0
+      '◯'
+    elsif time == 1
+      '／'
+    else
+      '△'
+    end
+  end
 end

--- a/app/views/admin/clinics/new.html.slim
+++ b/app/views/admin/clinics/new.html.slim
@@ -71,21 +71,21 @@
                           | 〜
                           = consultation_hour.select :finish_time, time_list
                         td 
-                          = consultation_hour.select :mo_time, { '●': 0, '／': 1, '▲': 2}
+                          = consultation_hour.select :mo_time
                         td
-                          = consultation_hour.select :tu_time, { '●': 0, '／': 1, '▲': 2}
+                          = consultation_hour.select :tu_time, { '●': 0, '／': 1, '▲': 2 }
                         td
-                          = consultation_hour.select :we_time, { '●': 0, '／': 1, '▲': 2}
+                          = consultation_hour.select :we_time, { '●': 0, '／': 1, '▲': 2 }
                         td
-                          = consultation_hour.select :th_time, { '●': 0, '／': 1, '▲': 2}
+                          = consultation_hour.select :th_time, { '●': 0, '／': 1, '▲': 2 }
                         td
-                          = consultation_hour.select :fr_time, { '●': 0, '／': 1, '▲': 2}
+                          = consultation_hour.select :fr_time, { '●': 0, '／': 1, '▲': 2 }
                         td
-                          = consultation_hour.select :sa_time, { '●': 0, '／': 1, '▲': 2}
+                          = consultation_hour.select :sa_time, { '●': 0, '／': 1, '▲': 2 }
                         td
-                          = consultation_hour.select :su_time, { '●': 0, '／': 1, '▲': 2}
+                          = consultation_hour.select :su_time, { '●': 0, '／': 1, '▲': 2 }
                         td
-                          = consultation_hour.select :ho_time, { '●': 0, '／': 1, '▲': 2}
+                          = consultation_hour.select :ho_time, { '●': 0, '／': 1, '▲': 2 }
                         
           = f.add_nested_fields_link :consultation_hours, '＋', class:"btn btn-default btn-xs"
           

--- a/app/views/member/clinics/_clinic_consultation_hours.html.slim
+++ b/app/views/member/clinics/_clinic_consultation_hours.html.slim
@@ -17,18 +17,18 @@ thead
           | 〜
           = consultation_hour.finish_time
         td 
-          = consultation_hour.mo_time
+          = consultation_hour.time_status(consultation_hour.mo_time)
         td
-          = consultation_hour.tu_time
+          = consultation_hour.time_status(consultation_hour.th_time)
         td
-          = consultation_hour.we_time
+          = consultation_hour.time_status(consultation_hour.we_time)
         td
-          = consultation_hour.th_time
+          = consultation_hour.time_status(consultation_hour.th_time)
         td
-          = consultation_hour.fr_time
+          = consultation_hour.time_status(consultation_hour.fr_time)
         td
-          = consultation_hour.sa_time
+          = consultation_hour.time_status(consultation_hour.sa_time)
         td
-          = consultation_hour.su_time
+          = consultation_hour.time_status(consultation_hour.su_time)
         td
-          = consultation_hour.ho_time
+          = consultation_hour.time_status(consultation_hour.ho_time)

--- a/spec/models/consultation_hour_spec.rb
+++ b/spec/models/consultation_hour_spec.rb
@@ -14,14 +14,23 @@ RSpec.describe ConsultationHour, type: :model do
     end
   end
   
-  describe "enum" do
-    it { is_expected.to define_enum_for(:mo_time)}
-    it { is_expected.to define_enum_for(:tu_time)}
-    it { is_expected.to define_enum_for(:we_time)}
-    it { is_expected.to define_enum_for(:th_time)}
-    it { is_expected.to define_enum_for(:fr_time)}
-    it { is_expected.to define_enum_for(:sa_time)}
-    it { is_expected.to define_enum_for(:su_time)}
-    it { is_expected.to define_enum_for(:ho_time)}
+  describe "#time_status" do
+    before do
+      clinic = create(:clinic)
+      ConsultationHour.create!(clinic_id: clinic.id, mo_time: 0, tu_time: 1, we_time: 2)
+      @consultation_hour = ConsultationHour.first
+    end
+    
+    it "条件に該当する文字列'◯'を返すこと" do
+      expect(@consultation_hour.time_status(@consultation_hour.mo_time)).to eq '◯'
+    end
+
+    it "条件に該当する文字列'／'を返すこと" do
+      expect(@consultation_hour.time_status(@consultation_hour.tu_time)).to eq '／'
+    end
+
+    it "条件に該当する文字列'△'を返すこと" do
+      expect(@consultation_hour.time_status(@consultation_hour.we_time)).to eq '△'
+    end
   end
 end


### PR DESCRIPTION
## 概要
診療時間の表示方法を修正
## 変更内容
enumを廃止
## テストの有無
あり
### テスト結果
```
ConsultationHour
  #time_status
    条件に該当する文字列'◯'を返すこと
    条件に該当する文字列'／'を返すこと
    条件に該当する文字列'△'を返すこと

Finished in 1.34 seconds (files took 4.23 seconds to load)
3 examples, 0 failures
```
### ありの場合
<!-- 具体的なテスト項目を記載 -->
### なしの場合
<!-- 実装しなかった理由を記載 -->
### 動作確認
<!-- 期待する挙動と確認した手順を記載 -->
